### PR TITLE
Remove autodestruction of batches

### DIFF
--- a/index.js
+++ b/index.js
@@ -229,6 +229,7 @@ module.exports = exports = class RocksDB extends ReadyResource {
     const batch = this.read(opts)
     const value = batch.get(key)
     await batch.flush()
+    batch.destroy()
     return value
   }
 
@@ -236,18 +237,21 @@ module.exports = exports = class RocksDB extends ReadyResource {
     const batch = this.write(opts)
     batch.put(key, value)
     await batch.flush()
+    batch.destroy()
   }
 
   async delete(key, opts) {
     const batch = this.write(opts)
     batch.delete(key)
     await batch.flush()
+    batch.destroy()
   }
 
   async deleteRange(start, end, opts) {
     const batch = this.write(opts)
     batch.deleteRange(start, end)
     await batch.flush()
+    batch.destroy()
   }
 }
 

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -3,7 +3,7 @@ const b4a = require('b4a')
 const binding = require('../binding')
 
 const empty = b4a.alloc(0)
-const emptyPromise = Promise.resolve()
+const resolved = Promise.resolve()
 
 class RocksDBBatch {
   constructor(db, opts = {}) {
@@ -12,8 +12,7 @@ class RocksDBBatch {
       capacity = 8,
       encoding = null,
       keyEncoding = encoding,
-      valueEncoding = encoding,
-      autoDestroy = true
+      valueEncoding = encoding
     } = opts
 
     db._ref()
@@ -27,12 +26,11 @@ class RocksDBBatch {
 
     this._keyEncoding = keyEncoding
     this._valueEncoding = valueEncoding
-    this._autoDestroy = autoDestroy !== false
 
     this._enqueuePromise = this._enqueuePromise.bind(this)
 
     this._request = null
-    this._resolveRequest = null
+    this._resolve = null
 
     this._handle = null
     this._buffer = null
@@ -41,13 +39,12 @@ class RocksDBBatch {
   }
 
   _onfinished() {
-    const resolve = this._resolveRequest
+    const resolve = this._resolve
 
     this._operations = []
     this._promises = []
     this._request = null
-    this._resolveRequest = null
-    if (this._autoDestroy) this.destroy()
+    this._resolve = null
 
     if (resolve !== null) resolve()
   }
@@ -71,28 +68,32 @@ class RocksDBBatch {
   }
 
   destroy() {
-    if (this._request) throw new Error('Batch already flushed')
+    if (this._request) throw new Error('Request in progress')
     if (this._destroyed) return
+
     this._destroyed = true
+
     this._db._unref()
   }
 
   flush() {
+    if (this._request) throw new Error('Request in progress')
     if (this._destroyed) throw new Error('Batch is destroyed')
-    if (this._request) throw new Error('Request already in progress')
 
     this._request = new Promise((resolve) => {
-      this._resolveRequest = resolve
+      this._resolve = resolve
     })
+
     this._flush()
 
     return this._request
   }
 
   tryFlush() {
-    if (this._request) throw new Error('Request already in progress')
+    if (this._request) throw new Error('Request in progress')
 
-    this._request = emptyPromise
+    this._request = resolved
+
     this._flush()
   }
 
@@ -183,6 +184,7 @@ exports.ReadBatch = class RocksDBReadBatch extends RocksDBBatch {
     const promise = new Promise(this._enqueuePromise)
 
     this._operations.push(new RocksDBGet(this._encodeKey(key), columnFamily))
+
     this._resize()
 
     return promise
@@ -239,6 +241,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
         columnFamily
       )
     )
+
     this._resize()
 
     return promise
@@ -256,7 +259,9 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
         columnFamily
       )
     )
+
     this._promises.push(null)
+
     this._resize()
   }
 
@@ -268,6 +273,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     const promise = new Promise(this._enqueuePromise)
 
     this._operations.push(new RocksDBDelete(this._encodeKey(key), columnFamily))
+
     this._resize()
 
     return promise
@@ -279,7 +285,9 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     const { columnFamily = this._columnFamily } = opts
 
     this._operations.push(new RocksDBDelete(this._encodeKey(key), columnFamily))
+
     this._promises.push(null)
+
     this._resize()
   }
 
@@ -297,6 +305,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
         columnFamily
       )
     )
+
     this._resize()
 
     return promise
@@ -314,7 +323,9 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
         columnFamily
       )
     )
+
     this._promises.push(null)
+
     this._resize()
   }
 }


### PR DESCRIPTION
Autodestruction of batches is a divergence from the underlying https://github.com/holepunchto/librocksdb API and results in an API that favours one-off batches instead of reusing existing batches. By requiring an explicit `batch.destroy()` for _all_ uses, the API is simplified for the favoured path while still allowing for one-off batches.