### PR TITLE
session based api

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -4,6 +4,7 @@
 #include <rocksdb.h>
 #include <stdlib.h>
 #include <utf.h>
+#include <string.h>
 
 typedef struct {
   uint32_t low;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,10 @@ class RocksDB {
     })
   }
 
+  columnFamily (name) {
+    return this.session({ columnFamily: name })
+  }
+
   snapshot() {
     let snapshot = this._snapshot
 

--- a/index.js
+++ b/index.js
@@ -1,208 +1,95 @@
-const ReadyResource = require('ready-resource')
-const binding = require('./binding')
 const { ReadBatch, WriteBatch } = require('./lib/batch')
+const ColumnFamily = require('./lib/column-family')
 const Iterator = require('./lib/iterator')
 const Snapshot = require('./lib/snapshot')
-const ColumnFamily = require('./lib/column-family')
+const DBState = require('./lib/state')
 
-module.exports = exports = class RocksDB extends ReadyResource {
+class RocksDB {
   constructor(path, opts = {}) {
-    const defaultColumnFamily = new ColumnFamily('default', opts)
-
     const {
-      columnFamilies = [],
-      readOnly = false,
-      createIfMissing = true,
-      createMissingColumnFamilies = true,
-      maxBackgroundJobs = 6,
-      bytesPerSync = 1048576
+      columnFamily,
+      state = new DBState(this, path, opts),
+      snapshot = null
     } = opts
 
-    super()
+    this._state = state
+    this._snapshot = snapshot
+    this._columnFamily = state.getColumnFamily(columnFamily)
+    this._destroyed = false
 
-    this._path = path
-    this._columnFamilies = [defaultColumnFamily, ...columnFamilies]
-    this._snapshots = new Set()
-    this._refs = 0
-    this._onpreclose = null
-    this._onidle = null
-    this._suspending = null
-    this._resuming = null
-    this._idling = null
+    this._state.refSession()
+  }
 
-    this._handle = binding.init(
-      Uint32Array.from([
-        readOnly ? 1 : 0,
-        createIfMissing ? 1 : 0,
-        createMissingColumnFamilies ? 1 : 0,
-        maxBackgroundJobs,
-        bytesPerSync & 0xffffffff,
-        Math.floor(bytesPerSync / 0x100000000)
-      ])
-    )
+  get opened() {
+    return this._state.opened
+  }
+
+  get closed() {
+    return this._state.clsoed
   }
 
   get path() {
-    return this._path
+    return this._state.path
   }
 
   get defaultColumnFamily() {
-    return this._columnFamilies[0]
+    return this._columnFamily
   }
 
-  async _open() {
-    const req = { resolve: null, reject: null, handle: null }
-
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
+  session({ columnFamily = this._columnFamily } = {}) {
+    return new RocksDB(null, {
+      state: this._state,
+      columnFamily,
+      snapshot: null
     })
-
-    req.handle = binding.open(
-      this._handle,
-      this,
-      this._path,
-      this._columnFamilies.map((c) => c._handle),
-      req,
-      onopen
-    )
-
-    await promise
-
-    for (const snapshot of this._snapshots) snapshot._init()
-
-    function onopen(err) {
-      if (err) req.reject(new Error(err))
-      else req.resolve()
-    }
   }
 
-  async _close() {
-    if (this._refs > 0) {
-      await new Promise((resolve) => {
-        this._onpreclose = resolve
-      })
-    }
+  snapshot() {
+    let snapshot = this._snapshot
 
-    for (const columnFamily of this._columnFamilies) columnFamily.destroy()
-    for (const snapshot of this._snapshots) snapshot.destroy()
+    if (snapshot === null) snapshot = new Snapshot(this._state)
+    else snapshot.ref()
 
-    const req = { resolve: null, reject: null, handle: null }
-
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
+    return new RocksDB(null, {
+      state: this._state,
+      columnFamily: this._columnFamily,
+      snapshot
     })
-
-    req.handle = binding.close(this._handle, req, onclose)
-
-    await promise
-
-    function onclose(err) {
-      if (err) req.reject(new Error(err))
-      else req.resolve()
-    }
   }
 
-  _ref() {
-    if (this.closing !== null) {
-      throw new Error('Database closed')
-    }
-
-    this._refs++
+  isRoot() {
+    return this === this._state.db
   }
 
-  _unref() {
-    if (--this._refs !== 0) return
-
-    if (this._onidle !== null) {
-      const resolve = this._onidle
-      this._onidle = null
-      this._idling = null
-      resolve()
-    }
-
-    if (this._onpreclose !== null) {
-      const resolve = this._onpreclose
-      this._onpreclose = null
-      resolve()
-    }
+  ready() {
+    return this._state.ready()
   }
 
-  async suspend() {
-    if (this.opened === false) await this.ready()
-    if (this._suspending === null) this._suspending = this._suspend()
-    return this._suspending
-  }
-
-  async _suspend() {
-    if (this._resuming) await this._resuming
-
-    const req = { resolve: null, reject: null, handle: null }
-
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
-    })
-
-    req.handle = binding.suspend(this._handle, req, onsuspend)
-
-    await promise
-
-    this._suspending = null
-
-    function onsuspend(err) {
-      if (err) req.reject(new Error(err))
-      else req.resolve()
+  close() {
+    if (!this._destroyed) {
+      this._destroyed = true
+      this._state.unrefSession()
+      if (this._snapshot) this._snapshot.unref()
     }
+
+    if (this.isRoot()) return this._state.close()
+    return Promise.resolve()
   }
 
-  async resume() {
-    if (this.opened === false) await this.ready()
-    if (this._resuming === null) this._resuming = this._resume()
-    return this._resuming
+  suspend() {
+    return this._state.suspend()
   }
 
-  async _resume() {
-    if (this._suspending) await this._suspending
-
-    const req = { resolve: null, reject: null, handle: null }
-
-    const promise = new Promise((resolve, reject) => {
-      req.resolve = resolve
-      req.reject = reject
-    })
-
-    req.handle = binding.resume(this._handle, req, onresume)
-
-    await promise
-
-    this._resuming = null
-
-    function onresume(err) {
-      if (err) req.reject(new Error(err))
-      else req.resolve()
-    }
+  resume() {
+    return this._state.resume()
   }
 
   isIdle() {
-    return this._refs === 0
+    return this._state.refs.isIdle()
   }
 
   idle() {
-    if (this.isIdle()) return Promise.resolve()
-
-    if (!this._idling) {
-      this._idling = new Promise((resolve) => {
-        this._onidle = resolve
-      })
-    }
-
-    return this._idling
-  }
-
-  snapshot(opts) {
-    return new Snapshot(this, opts)
+    return this._state.refs.idle()
   }
 
   iterator(range, opts) {
@@ -267,4 +154,5 @@ module.exports = exports = class RocksDB extends ReadyResource {
   }
 }
 
+module.exports = exports = RocksDB
 exports.ColumnFamily = ColumnFamily

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class RocksDB {
   }
 
   get closed() {
-    return this._state.clsoed
+    return this._state.closed
   }
 
   get path() {

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ class RocksDB {
   }
 
   get closed() {
-    return this._state.closed
+    return this.isRoot() ? this._state.closed : this._destroyed
   }
 
   get path() {

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ class RocksDB {
     })
   }
 
-  columnFamily (name) {
+  columnFamily(name) {
     return this.session({ columnFamily: name })
   }
 

--- a/index.js
+++ b/index.js
@@ -36,11 +36,22 @@ class RocksDB {
     return this._columnFamily
   }
 
-  session({ columnFamily = this._columnFamily } = {}) {
+  session({
+    columnFamily = this._columnFamily,
+    snapshot = this._snapshot !== null
+  } = {}) {
+    let snap = null
+
+    if (snapshot) {
+      snap = this._snapshot
+      if (snap === null) snap = new Snapshot(this._state)
+      else snap.ref()
+    }
+
     return new RocksDB(null, {
       state: this._state,
       columnFamily,
-      snapshot: null
+      snapshot: snap
     })
   }
 
@@ -49,16 +60,7 @@ class RocksDB {
   }
 
   snapshot() {
-    let snapshot = this._snapshot
-
-    if (snapshot === null) snapshot = new Snapshot(this._state)
-    else snapshot.ref()
-
-    return new RocksDB(null, {
-      state: this._state,
-      columnFamily: this._columnFamily,
-      snapshot
-    })
+    return this.session({ snapshot: true })
   }
 
   isRoot() {

--- a/index.js
+++ b/index.js
@@ -76,8 +76,7 @@ class RocksDB {
       if (this._snapshot) this._snapshot.unref()
     }
 
-    if (this.isRoot()) return this._state.close()
-    return Promise.resolve()
+    return this.isRoot() ? this._state.close() : Promise.resolve()
   }
 
   suspend() {

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -14,9 +14,9 @@ class RocksDBBatch {
       valueEncoding = encoding
     } = opts
 
-    db._ref()
+    db._state.ref()
 
-    this._db = db
+    this._state = db._state
     this._columnFamily = columnFamily
     this._destroyed = false
     this._capacity = capacity
@@ -34,7 +34,7 @@ class RocksDBBatch {
     this._handle = null
     this._buffer = null
 
-    if (db.opened === true) this.ready()
+    if (this._state.opened === true) this.ready()
   }
 
   _onfinished() {
@@ -61,7 +61,7 @@ class RocksDBBatch {
   async ready() {
     if (this._handle !== null) return
 
-    if (this._db.opened === false) await this._db.ready()
+    if (this._state.opened === false) await this._state.ready()
 
     this._init()
   }
@@ -72,7 +72,7 @@ class RocksDBBatch {
 
     this._destroyed = true
 
-    this._db._unref()
+    this._state.unref()
   }
 
   flush() {
@@ -124,12 +124,10 @@ class RocksDBBatch {
 }
 
 exports.ReadBatch = class RocksDBReadBatch extends RocksDBBatch {
-  constructor(db, opts = {}) {
-    const { snapshot = null } = opts
-
+  constructor(db, opts) {
     super(db, opts)
 
-    this._snapshot = snapshot
+    this._snapshot = db._snapshot
   }
 
   _init() {
@@ -147,7 +145,7 @@ exports.ReadBatch = class RocksDBReadBatch extends RocksDBBatch {
     await super._flush()
 
     binding.read(
-      this._db._handle,
+      this._state.handle,
       this._handle,
       this._operations,
       this._snapshot ? this._snapshot._handle : null,
@@ -175,14 +173,14 @@ exports.ReadBatch = class RocksDBReadBatch extends RocksDBBatch {
     this._onfinished()
   }
 
-  get(key, opts = {}) {
+  get(key) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     const promise = new Promise(this._enqueuePromise)
 
-    this._operations.push(new RocksDBGet(this._encodeKey(key), columnFamily))
+    this._operations.push(
+      new RocksDBGet(this._encodeKey(key), this._columnFamily)
+    )
 
     this._resize()
 
@@ -206,7 +204,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     await super._flush()
 
     binding.write(
-      this._db._handle,
+      this._state.handle,
       this._handle,
       this._operations,
       this,
@@ -226,10 +224,8 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     this._onfinished()
   }
 
-  put(key, value, opts = {}) {
+  put(key, value) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     const promise = new Promise(this._enqueuePromise)
 
@@ -237,7 +233,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
       new RocksDBPut(
         this._encodeKey(key),
         this._encodeValue(value),
-        columnFamily
+        this._columnFamily
       )
     )
 
@@ -246,16 +242,14 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     return promise
   }
 
-  tryPut(key, value, opts = {}) {
+  tryPut(key, value) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     this._operations.push(
       new RocksDBPut(
         this._encodeKey(key),
         this._encodeValue(value),
-        columnFamily
+        this._columnFamily
       )
     )
 
@@ -264,36 +258,34 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     this._resize()
   }
 
-  delete(key, opts = {}) {
+  delete(key) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     const promise = new Promise(this._enqueuePromise)
 
-    this._operations.push(new RocksDBDelete(this._encodeKey(key), columnFamily))
+    this._operations.push(
+      new RocksDBDelete(this._encodeKey(key), this._columnFamily)
+    )
 
     this._resize()
 
     return promise
   }
 
-  tryDelete(key, opts = {}) {
+  tryDelete(key) {
     if (this._request) throw new Error('Request already in progress')
 
-    const { columnFamily = this._columnFamily } = opts
-
-    this._operations.push(new RocksDBDelete(this._encodeKey(key), columnFamily))
+    this._operations.push(
+      new RocksDBDelete(this._encodeKey(key), this._columnFamily)
+    )
 
     this._promises.push(null)
 
     this._resize()
   }
 
-  deleteRange(start, end, opts = {}) {
+  deleteRange(start, end) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     const promise = new Promise(this._enqueuePromise)
 
@@ -301,7 +293,7 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
       new RocksDBDeleteRange(
         this._encodeKey(start),
         this._encodeKey(end),
-        columnFamily
+        this._columnFamily
       )
     )
 
@@ -310,16 +302,14 @@ exports.WriteBatch = class RocksDBWriteBatch extends RocksDBBatch {
     return promise
   }
 
-  tryDeleteRange(start, end, opts = {}) {
+  tryDeleteRange(start, end) {
     if (this._request) throw new Error('Request already in progress')
-
-    const { columnFamily = this._columnFamily } = opts
 
     this._operations.push(
       new RocksDBDeleteRange(
         this._encodeKey(start),
         this._encodeKey(end),
-        columnFamily
+        this._columnFamily
       )
     )
 

--- a/lib/column-family.js
+++ b/lib/column-family.js
@@ -1,6 +1,6 @@
 const binding = require('../binding')
 
-module.exports = class RocksDBColumnFamily {
+class RocksDBColumnFamily {
   constructor(name, opts = {}) {
     const {
       // Blob options
@@ -11,13 +11,14 @@ module.exports = class RocksDBColumnFamily {
       // Block table options
       tableBlockSize = 16384,
       tableCacheIndexAndFilterBlocks = true,
-      tableFormatVersion = 4
+      tableFormatVersion = 4,
+      // In case we are cloning
+      settings = null
     } = opts
 
     this._name = name
-
-    this._handle = binding.columnFamilyInit(
-      name,
+    this._settings =
+      settings ||
       Uint32Array.from([
         0,
         enableBlobFiles ? 1 : 0,
@@ -31,7 +32,12 @@ module.exports = class RocksDBColumnFamily {
         tableCacheIndexAndFilterBlocks ? 1 : 0,
         tableFormatVersion
       ])
-    )
+
+    this._handle = binding.columnFamilyInit(name, this._settings)
+  }
+
+  cloneSettings(name) {
+    return new RocksDBColumnFamily(name, { settings: this._settings })
   }
 
   get name() {
@@ -46,3 +52,5 @@ module.exports = class RocksDBColumnFamily {
     this._handle = null
   }
 }
+
+module.exports = RocksDBColumnFamily

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -15,7 +15,6 @@ module.exports = class RocksDBIterator extends Readable {
       reverse = false,
       limit = Infinity,
       capacity = 8,
-      snapshot = null,
       encoding = null,
       keyEncoding = encoding,
       valueEncoding = encoding
@@ -23,9 +22,9 @@ module.exports = class RocksDBIterator extends Readable {
 
     super()
 
-    db._ref()
+    db._state.ref()
 
-    this._db = db
+    this._state = db._state
     this._columnFamily = columnFamily
 
     this._keyEncoding = keyEncoding
@@ -39,7 +38,7 @@ module.exports = class RocksDBIterator extends Readable {
     this._reverse = reverse
     this._limit = limit < 0 ? Infinity : limit
     this._capacity = capacity
-    this._snapshot = snapshot
+    this._snapshot = db._snapshot
 
     this._pendingOpen = null
     this._pendingRead = null
@@ -48,7 +47,7 @@ module.exports = class RocksDBIterator extends Readable {
     this._buffer = null
     this._handle = null
 
-    if (db.opened === true) this.ready()
+    if (this._state.opened === true) this.ready()
   }
 
   _onopen(err) {
@@ -81,7 +80,7 @@ module.exports = class RocksDBIterator extends Readable {
   _onclose(err) {
     const cb = this._pendingDestroy
     this._pendingDestroy = null
-    this._db._unref()
+    this._state.unref()
     cb(err)
   }
 
@@ -94,7 +93,7 @@ module.exports = class RocksDBIterator extends Readable {
   async ready() {
     if (this._handle !== null) return
 
-    if (this._db.opened === false) await this._db.ready()
+    if (this._state.opened === false) await this._state.ready()
 
     this._init()
   }
@@ -110,7 +109,7 @@ module.exports = class RocksDBIterator extends Readable {
     this._pendingOpen = cb
 
     binding.iteratorOpen(
-      this._db._handle,
+      this._state.handle,
       this._handle,
       this._columnFamily._handle,
       this._gt,

--- a/lib/snapshot.js
+++ b/lib/snapshot.js
@@ -1,21 +1,28 @@
 const binding = require('../binding')
 
 module.exports = class RocksDBSnapshot {
-  constructor(db) {
-    this._db = db
-    this._db._snapshots.add(this)
+  constructor(state) {
+    this._state = state
+    this._state.snapshots.add(this)
 
     this._handle = null
+    this._refs = 1
 
-    if (db.opened === true) this._init()
+    if (state.opened === true) this._init()
   }
 
   _init() {
-    this._handle = binding.snapshotCreate(this._db._handle)
+    this._handle = binding.snapshotCreate(this._state.handle)
   }
 
-  destroy() {
-    this._db._snapshots.delete(this)
+  ref() {
+    this._refs++
+  }
+
+  unref() {
+    if (--this._refs > 0) return
+
+    this._state.snapshots.delete(this)
 
     if (this._handle === null) return
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -26,6 +26,7 @@ module.exports = class DBState extends ReadyResource {
 
     this._suspending = null
     this._resuming = null
+    this._columnsFlushed = false
 
     for (const col of columnFamilies) {
       this.columnFamilies.push(
@@ -62,19 +63,41 @@ module.exports = class DBState extends ReadyResource {
     this.refs.dec()
   }
 
+  upsertColumnFamily(c) {
+    if (typeof c === 'string') {
+      let col = this.getColumnFamilyByName(c)
+      if (col) return col
+      col = this.columnFamilies[0].cloneSettings(c)
+      this.columnFamilies.push(col)
+      return col
+    }
+
+    if (this.columnFamilies.includes(c)) return c
+    this.columnFamilies.push(c)
+    return c
+  }
+
   getColumnFamily(c) {
     if (!c) return this.columnFamilies[0]
+    if (!this._columnsFlushed) return this.upsertColumnFamily(c)
 
     if (typeof c !== 'string') return c
 
-    for (const col of this.columnFamilies) {
-      if (col.name === c) return col
-    }
+    const col = this.getColumnFamilyByName(c)
+    if (col === null) throw new Error('Unknown column family')
+    return col
+  }
 
-    throw new Error('Unknown column family')
+  getColumnFamilyByName(name) {
+    for (const col of this.columnFamilies) {
+      if (col.name === name) return col
+    }
+    return null
   }
 
   async _open() {
+    await Promise.resolve() // allow column families to populate if ondemand
+
     const req = { resolve: null, reject: null, handle: null }
 
     const promise = new Promise((resolve, reject) => {
@@ -82,6 +105,7 @@ module.exports = class DBState extends ReadyResource {
       req.reject = reject
     })
 
+    this._columnsFlushed = true
     req.handle = binding.open(
       this.handle,
       this,

--- a/lib/state.js
+++ b/lib/state.js
@@ -1,0 +1,185 @@
+const ReadyResource = require('ready-resource')
+const RefCounter = require('refcounter')
+const ColumnFamily = require('./column-family')
+const binding = require('../binding')
+
+module.exports = class DBState extends ReadyResource {
+  constructor(db, path, opts) {
+    super()
+
+    const {
+      columnFamily = new ColumnFamily('default', opts),
+      columnFamilies = [],
+      readOnly = false,
+      createIfMissing = true,
+      createMissingColumnFamilies = true,
+      maxBackgroundJobs = 6,
+      bytesPerSync = 1048576
+    } = opts
+
+    this.path = path
+    this.db = db
+    this.refs = new RefCounter()
+    this.instances = new RefCounter()
+    this.columnFamilies = [columnFamily]
+    this.snapshots = new Set()
+
+    this._suspending = null
+    this._resuming = null
+
+    for (const col of columnFamilies) {
+      this.columnFamilies.push(
+        typeof col === 'string' ? new ColumnFamily(col, opts) : col
+      )
+    }
+
+    this.handle = binding.init(
+      Uint32Array.from([
+        readOnly ? 1 : 0,
+        createIfMissing ? 1 : 0,
+        createMissingColumnFamilies ? 1 : 0,
+        maxBackgroundJobs,
+        bytesPerSync & 0xffffffff,
+        Math.floor(bytesPerSync / 0x100000000)
+      ])
+    )
+  }
+
+  refSession() {
+    this.instances.inc()
+  }
+
+  unrefSession() {
+    this.instances.dec()
+  }
+
+  ref() {
+    if (this.closing) throw new Error('Database closed')
+    this.refs.inc()
+  }
+
+  unref() {
+    this.refs.dec()
+  }
+
+  getColumnFamily(c) {
+    if (!c) return this.columnFamilies[0]
+
+    if (typeof c !== 'string') return c
+
+    for (const col of this.columnFamilies) {
+      if (col.name === c) return col
+    }
+
+    throw new Error('Unknown column family')
+  }
+
+  async _open() {
+    const req = { resolve: null, reject: null, handle: null }
+
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
+
+    req.handle = binding.open(
+      this.handle,
+      this,
+      this.path,
+      this.columnFamilies.map((c) => c._handle),
+      req,
+      onopen
+    )
+
+    await promise
+
+    for (const snapshot of this.snapshots) snapshot._init()
+
+    function onopen(err) {
+      if (err) req.reject(new Error(err))
+      else req.resolve()
+    }
+  }
+
+  async _close() {
+    while (!this.refs.isIdle() || !this.instances.isIdle()) {
+      await this.refs.idle()
+      await this.instances.idle()
+    }
+
+    for (const columnFamily of this.columnFamilies) columnFamily.destroy()
+    for (const snapshot of this.snapshots) snapshot.destroy()
+
+    const req = { resolve: null, reject: null, handle: null }
+
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
+
+    req.handle = binding.close(this.handle, req, onclose)
+
+    await promise
+
+    function onclose(err) {
+      if (err) req.reject(new Error(err))
+      else req.resolve()
+    }
+  }
+
+  async suspend() {
+    if (this._suspending === null) this._suspending = this._suspend()
+    return this._suspending
+  }
+
+  async _suspend() {
+    if (this._resuming) await this._resuming
+    if (this.opened === false) await this.ready()
+
+    const req = { resolve: null, reject: null, handle: null }
+
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
+
+    req.handle = binding.suspend(this.handle, req, onsuspend)
+
+    await promise
+
+    this._suspending = null
+
+    function onsuspend(err) {
+      if (err) req.reject(new Error(err))
+      else req.resolve()
+    }
+  }
+
+  resume() {
+    if (this._resuming === null) this._resuming = this._resume()
+    return this._resuming
+  }
+
+  async _resume() {
+    if (this._suspending) await this._suspending
+    if (this.opened === false) await this.ready()
+
+    const req = { resolve: null, reject: null, handle: null }
+
+    const promise = new Promise((resolve, reject) => {
+      req.resolve = resolve
+      req.reject = reject
+    })
+
+    req.handle = binding.resume(this.handle, req, onresume)
+
+    await promise
+
+    this._resuming = null
+
+    function onresume(err) {
+      if (err) req.reject(new Error(err))
+      else req.resolve()
+    }
+  }
+}

--- a/lib/state.js
+++ b/lib/state.js
@@ -20,7 +20,8 @@ module.exports = class DBState extends ReadyResource {
     this.path = path
     this.db = db
     this.refs = new RefCounter()
-    this.instances = new RefCounter()
+    this.sessionRefs = new RefCounter()
+    this.sessions = []
     this.columnFamilies = [columnFamily]
     this.snapshots = new Set()
 
@@ -46,12 +47,15 @@ module.exports = class DBState extends ReadyResource {
     )
   }
 
-  refSession() {
-    this.instances.inc()
+  addSession(db) {
+    this.sessionRefs.inc()
+    db._index = this.sessions.push(db) - 1
   }
 
-  unrefSession() {
-    this.instances.dec()
+  removeSession(db) {
+    this.sessionRefs.dec()
+    const head = this.sessions.pop()
+    if (head !== db) this.sessions[(head._index = db._index)] = head
   }
 
   ref() {
@@ -126,9 +130,9 @@ module.exports = class DBState extends ReadyResource {
   }
 
   async _close() {
-    while (!this.refs.isIdle() || !this.instances.isIdle()) {
+    while (!this.refs.isIdle() || !this.sessionRefs.isIdle()) {
       await this.refs.idle()
-      await this.instances.idle()
+      await this.sessionRefs.idle()
     }
 
     for (const columnFamily of this.columnFamilies) columnFamily.destroy()

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "compact-encoding": "^2.15.0",
     "ready-resource": "^1.0.0",
+    "refcounter": "^1.0.0",
     "require-addon": "^1.0.2",
     "streamx": "^2.16.1"
   },

--- a/test.js
+++ b/test.js
@@ -578,3 +578,18 @@ test('column families, batch per family', async (t) => {
   await b.close()
   await db.close()
 })
+
+test('column families setup implicitly', async (t) => {
+  const db = new RocksDB(await tmp(t))
+
+  const a = db.columnFamily('a')
+  const b = db.columnFamily('b')
+
+  await b.put('hello', 'world')
+  t.is(await a.get('hello'), null)
+  t.alike(await b.get('hello'), Buffer.from('world'))
+
+  await a.close()
+  await b.close()
+  await db.close()
+})


### PR DESCRIPTION
Now the main abstraction is a light weight session, ie

```
const session = db.session() // has the same interface as db
const snapshot = db.snapshot() // db but bound to a snap
const col = db.session({ columnFamily: 'a' }) // column family
const col = db.columnFamily('a') // alias for the above
```

Removes the columnFamily option from most apis as the preferred way is through sessions.
If needed we can add a way to express cross column family batches but for now no need

(major bump)