### PR TITLE
Default format version 6 and block size 8kb

### DIFF
--- a/lib/column-family.js
+++ b/lib/column-family.js
@@ -11,7 +11,7 @@ class RocksDBColumnFamily {
       // Block table options
       tableBlockSize = 16384,
       tableCacheIndexAndFilterBlocks = true,
-      tableFormatVersion = 4,
+      tableFormatVersion = 5,
       // In case we are cloning
       settings = null
     } = opts

--- a/lib/column-family.js
+++ b/lib/column-family.js
@@ -9,7 +9,7 @@ class RocksDBColumnFamily {
       blobFileSize = 0,
       enableBlobGarbageCollection = true,
       // Block table options
-      tableBlockSize = 16384,
+      tableBlockSize = 8192,
       tableCacheIndexAndFilterBlocks = true,
       tableFormatVersion = 6,
       // In case we are cloning

--- a/lib/column-family.js
+++ b/lib/column-family.js
@@ -11,7 +11,7 @@ class RocksDBColumnFamily {
       // Block table options
       tableBlockSize = 16384,
       tableCacheIndexAndFilterBlocks = true,
-      tableFormatVersion = 5,
+      tableFormatVersion = 6,
       // In case we are cloning
       settings = null
     } = opts


### PR DESCRIPTION
6 is the latest stable `format_version` (since RocksDB 8.6.0), so don't think we should default to 4 as we have no compatibility concerns at this stage. 

Also sets the default `block_size` to 8kb as this seems more suitable for general workloads.