### PR TITLE
add failing suspend tests on batch promise teardown

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -43,12 +43,13 @@ class RocksDBBatch {
     const resolve = this._resolve
     const reject = this._reject
 
+    if (this._request) this._db._state.io.dec()
+
     this._operations = []
     this._promises = []
     this._request = null
     this._resolve = null
     this._reject = null
-    this._db._state.io.dec()
 
     if (this._autoDestroy === true) this.destroy()
 

--- a/test.js
+++ b/test.js
@@ -936,6 +936,45 @@ test('iterator + suspend + close', async (t) => {
   await t.exception(p)
 })
 
+test('make a batch, queue read, destroy + suspend + close', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  await db.ready()
+
+  const batch = db.read()
+
+  batch.get(Buffer.from('hello')).catch(noop)
+  batch.destroy()
+
+  await db.suspend()
+  await db.close()
+})
+
+test('make a batch, queue write, destroy + suspend + close', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  await db.ready()
+
+  const batch = db.write()
+
+  batch.put(Buffer.from('hello'), Buffer.from('world')).catch(noop)
+  batch.destroy()
+
+  await db.suspend()
+  await db.close()
+})
+
+test('make a batch, queue delete, destroy + suspend + close', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  await db.ready()
+
+  const batch = db.write()
+
+  batch.delete(Buffer.from('hello')).catch(noop)
+  batch.destroy()
+
+  await db.suspend()
+  await db.close()
+})
+
 test('suspend + open new writer', async (t) => {
   const dir = await t.tmp()
 
@@ -987,3 +1026,5 @@ test('suspend + flush + resume', async (t) => {
 
   await db.close()
 })
+
+function noop() {}


### PR DESCRIPTION
fix is prop checking if we are actually flushing before calling .dec() - it goes negative in these tests