### PR TITLE
exposes diagnostics state

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,10 @@ class RocksDB {
     if (this._snapshot) this._snapshot.unref()
     this._state.handles.dec()
   }
+
+  diagnosis() {
+    return this._state.diagnosis()
+  }
 }
 
 module.exports = exports = RocksDB

--- a/index.js
+++ b/index.js
@@ -209,8 +209,8 @@ class RocksDB {
     this._state.handles.dec()
   }
 
-  diagnosis() {
-    return this._state.diagnosis()
+  diagnostics() {
+    return this._state.diagnostics()
   }
 }
 

--- a/lib/state.js
+++ b/lib/state.js
@@ -433,7 +433,7 @@ module.exports = class RocksDBState extends ReadyResource {
     return k
   }
 
-  diagnosis() {
+  diagnostics() {
     return {
       suspended: this._suspended,
       suspending: this._suspending,

--- a/lib/state.js
+++ b/lib/state.js
@@ -438,7 +438,7 @@ module.exports = class RocksDBState extends ReadyResource {
       suspended: this._suspended,
       suspending: this._suspending,
       updating: this._updating,
-      resumedPending: this.resume != null,
+      resumedPending: this.resumed !== null,
       io: this.io.count,
       handles: this.handles.count,
       sessions: this.sessions.length

--- a/lib/state.js
+++ b/lib/state.js
@@ -432,4 +432,16 @@ module.exports = class RocksDBState extends ReadyResource {
     if (k === null) return empty
     return k
   }
+
+  diagnosis() {
+    return {
+      suspended: this._suspended,
+      suspending: this._suspending,
+      updating: this._updating,
+      resumedPending: this.resume != null,
+      io: this.io.count,
+      handles: this.handles.count,
+      sessions: this.sessions.length
+    }
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1304,6 +1304,7 @@ test('diagnostics reflects state', async (t) => {
       handles: 0,
       sessions: 1
     })
+    t.comment(db.diagnostics())
   }
 
   {

--- a/test.js
+++ b/test.js
@@ -1288,4 +1288,55 @@ test('stats', async (t) => {
   await db.close()
 })
 
+test('diagnostics reflects state', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  t.teardown(() => db.close())
+
+  await db.ready()
+
+  {
+    t.alike(db.diagnostics(), {
+      suspended: false,
+      suspending: false,
+      updating: false,
+      resumedPending: false,
+      io: 0,
+      handles: 0,
+      sessions: 1
+    })
+  }
+
+  {
+    const s = db.session()
+    t.is(db.diagnostics().sessions, 2)
+    await s.close()
+    t.is(db.diagnostics().sessions, 1)
+  }
+
+  {
+    const batch = db.read()
+    t.is(db.diagnostics().handles, 1)
+    await batch.destroy()
+    t.is(db.diagnostics().handles, 0)
+  }
+
+  {
+    await db.suspend()
+    const d = db.diagnostics()
+    t.is(d.suspended, true)
+    // resumed promise is set until resume() clears it
+    t.is(d.resumedPending, true)
+
+    await db.resume()
+    const d2 = db.diagnostics()
+    t.is(d2.suspended, false)
+    t.is(d2.resumedPending, false)
+  }
+
+  {
+    await db.suspend()
+    t.is(db.diagnostics().suspended, true)
+  }
+})
+
 function noop() {}


### PR DESCRIPTION
This change adds a utility method `diagnostics()` to the state and db so that external usage can reach in to read the internal state for observability purposes.