### PR TITLE
Hold work issued while suspending

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -138,7 +138,7 @@ class RocksDBBatch {
     this._db._state.io.inc()
 
     if (this._db._state.resumed !== null) {
-      const resumed = await this._db._state.resumed.promise
+      const resumed = await this._db._state.waitForResume()
 
       if (!resumed) {
         if (this._destroyed) {

--- a/lib/iterator.js
+++ b/lib/iterator.js
@@ -107,7 +107,7 @@ module.exports = class RocksDBIterator extends Readable {
     this._db._state.io.inc()
 
     if (this._db._state.resumed !== null) {
-      const resumed = await this._db._state.resumed.promise
+      const resumed = await this._db._state.waitForResume()
 
       if (!resumed) {
         this._db._state.io.dec()
@@ -146,7 +146,7 @@ module.exports = class RocksDBIterator extends Readable {
     this._db._state.io.inc()
 
     if (this._db._state.resumed !== null) {
-      const resumed = await this._db._state.resumed.promise
+      const resumed = await this._db._state.waitForResume()
 
       if (!resumed) {
         this._db._state.io.dec()

--- a/lib/state.js
+++ b/lib/state.js
@@ -240,7 +240,7 @@ module.exports = class RocksDBState extends ReadyResource {
     this.io.inc()
 
     if (this.resumed !== null) {
-      const resumed = await this.resumed.promise
+      const resumed = await this.waitForResume()
 
       if (!resumed) {
         this.io.dec()
@@ -293,13 +293,22 @@ module.exports = class RocksDBState extends ReadyResource {
     }
   }
 
+  async waitForResume() {
+    while (this.resumed !== null) {
+      this.io.dec()
+      const resumed = await this.resumed.promise
+      this.io.inc()
+      if (resumed === false) return false
+    }
+    return true
+  }
+
   async _suspend() {
     if (this._suspended === true) return
 
-    while (!this.io.isIdle()) await this.io.idle()
-
-    this.io.inc()
     this.resumed = rrp()
+    while (!this.io.isIdle()) await this.io.idle()
+    this.io.inc()
 
     const req = { resolve: null, reject: null, handle: null }
 

--- a/test.js
+++ b/test.js
@@ -941,6 +941,61 @@ test('suspend + write', async (t) => {
   await db.close()
 })
 
+test('write while suspending', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  await db.ready()
+
+  const busy = db.write()
+  busy.tryPut('busy', 'value')
+  const busyFlushed = busy.flush()
+
+  const suspending = db.suspend()
+
+  let flushed = false
+  const batch = db.write()
+  const p = batch.put('hello', 'world')
+  batch.flush().then(() => (flushed = true))
+
+  await busyFlushed
+  busy.destroy()
+  await suspending
+
+  t.is(flushed, false)
+
+  await db.resume()
+  await p
+  batch.destroy()
+  await db.close()
+})
+
+test('read while suspending', async (t) => {
+  const db = new RocksDB(await t.tmp())
+  await db.ready()
+
+  const busy = db.write()
+  busy.tryPut('hello', 'world')
+  const busyFlushed = busy.flush()
+
+  const suspending = db.suspend()
+
+  let flushed = false
+  const batch = db.read()
+  const p = batch.get('hello')
+  batch.flush().then(() => (flushed = true))
+
+  await busyFlushed
+  busy.destroy()
+  await suspending
+
+  t.is(flushed, false)
+
+  await db.resume()
+  t.alike(await p, Buffer.from('world'))
+  batch.destroy()
+
+  await db.close()
+})
+
 test('suspend + write + resume + suspend before fully resumed', async (t) => {
   const db = new RocksDB(await t.tmp())
   await db.ready()


### PR DESCRIPTION
`suspend()` can't finish if anything keeps using the db while it's running.

`_suspend()` waits for the in flight io count to reach zero, then arms `this.resumed` so new operations queue up instead of running:

```js
while (!this.io.isIdle()) await this.io.idle()   // drain

this.io.inc()
this.resumed = rrp()                             // only now do new ops wait
```

The gate is set after the drain has already succeeded. So while we're draining, `resumed` is still `null`, every operation sees a normal db and runs for real, and each one puts the count back up. The wait has no timeout and no cancel, so on a busy db it can sit there indefinitely.

Once suspended it behaves correctly, work is held until resume. It's only the window in between that leaks.